### PR TITLE
TF 0.12 conversion for docs

### DIFF
--- a/iac/available-modules.md
+++ b/iac/available-modules.md
@@ -14,12 +14,12 @@ To use one of these modules, you can put a reference to Github in as the local m
 ```hcl
 module "alb" {
     // The double slash IS significant <https://www.terraform.io/docs/modules/sources.html#modules-in-package-sub-directories>
-    source = "github.com/NIT-Administrative-Systems/AS-Common-AWS-Modules//alb"
+    source = "github.com/NIT-Administrative-Systems/AS-Common-AWS-Modules//alb?ref=tf-0.12"
 
     region = "us-east-2"
-    account_label = "${var.account_label}"
-    vpc_id = "${var.vpc_id}"
-    subnets = ["${var.alb_subnets}"]
+    account_label = var.account_label
+    vpc_id = var.vpc_id
+    subnets = var.alb_subnets
 }
 ```
 

--- a/iac/example-tf.md
+++ b/iac/example-tf.md
@@ -26,9 +26,9 @@ Generating the certificate with the module that the AS Cloud Services team has a
 # cert (with one hostname).
 module "certificate" {
     // The double slash IS significant <https://www.terraform.io/docs/modules/sources.html#modules-in-package-sub-directories>
-    source = "github.com/NIT-Administrative-Systems/AS-Common-AWS-Modules//entapp_certificate"
+    source = "github.com/NIT-Administrative-Systems/AS-Common-AWS-Modules//entapp_certificate?ref=tf-0.12"
 
-    hostnames = ["${var.hostnames}"]
+    hostnames = var.hostnames
 }
 ```
 
@@ -45,9 +45,9 @@ data "terraform_remote_state" "account_wide_alb" {
   backend = "s3"
 
   config = {
-    bucket = "${var.alb_state_bucket}"
-    key    = "${var.alb_state_file}"
-    region = "${var.alb_state_region}"
+    bucket = var.alb_state_bucket
+    key    = var.alb_state_file
+    region = var.alb_state_region
   }
 }
 
@@ -58,11 +58,11 @@ data "terraform_remote_state" "account_wide_alb" {
 # This also uses the certificate_arn attribute of the cert module we invoked in the
 # previous example.
 resource "aws_lb_listener" "lb_listener" {
-    load_balancer_arn = "${data.terraform_remote_state.account_wide_alb.lb_arn}"
+    load_balancer_arn = data.terraform_remote_state.account_wide_alb.outputs.lb_arn
     port              = "443"
     protocol          = "HTTPS"
     ssl_policy        = "ELBSecurityPolicy-2016-08"
-    certificate_arn   = "${module.certificate.certificate_arn}"
+    certificate_arn   = module.certificate.certificate_arn
 
     default_action {
         type = "fixed-response"
@@ -78,7 +78,7 @@ resource "aws_lb_listener" "lb_listener" {
 #
 # You will need to access this in the per-environment module.
 output "alb_listener_arn" {
-    value = "${aws_lb_listener.lb_listener.arn}"
+    value = aws_lb_listener.lb_listener.arn
 }
 ```
 

--- a/iac/terraform-concepts.md
+++ b/iac/terraform-concepts.md
@@ -54,7 +54,7 @@ resource "aws_sns_topic" "opsgenie_alert_topic" {
 # using the Amazon Resource Name (ARN) that the previous resource
 # output.
 resource "aws_sns_topic_subscription" "opsgenie_integration" {
-  topic_arn              = "${aws_sns_topic.opsgenie_alert_topic.arn}"
+  topic_arn              = aws_sns_topic.opsgenie_alert_topic.arn"
   protocol               = "https"
   endpoint               = "https://api.opsgenie.com/alert/SomeTeam?apiKey=MyVeryCoolSecret"
   endpoint_auto_confirms = true

--- a/iac/terraform-concepts.md
+++ b/iac/terraform-concepts.md
@@ -7,12 +7,10 @@ All cloud resources in the prod & nonprod environments must be created as IaC, a
 
 For the most part, AS developers will only need to be concerned with the [AWS provider](https://www.terraform.io/docs/providers/aws/index.html). But if the need arises, you can use terraform to build infrastructure for one app across several cloud vendors.
 
-:::danger Terraform v0.10
-At this time, Terraform v0.10 is the default installed on all Jenkins servers.
+:::warning Terraform Version
+Prior to January 2020, we used Terraform v0.10. We are in the process of migrating to TF 0.12. 
 
-Be aware of your target Terraform version when reading & writing code. v0.12 made significant changes to the syntax.
-
-When reviewing Terraform documentation, verify the docs are either for v0.11 and before (pre-2020 AS terraform modules) or for v0.12 (written in 2020 and beyond). 
+All new IaC development should be done using TF 0.12. We recommend installing [`tfenv`](https://github.com/tfutils/tfenv) to manage your TF versions.
 
 You should upgrade your older modules to v0.12 -- see the AS [upgrade guide](./tf-upgrading.md) for guidance.
 :::

--- a/infrastructure/vpc-ip-addr.md
+++ b/infrastructure/vpc-ip-addr.md
@@ -27,19 +27,19 @@ data "terraform_remote_state" "account_resources" {
   backend = "s3"
 
   config = {
-    bucket = "${var.account_resources_state_bucket}"
-    key    = "${var.account_resources_state_file}"
-    region = "${var.account_resources_state_region}"
+    bucket = var.account_resources_state_bucket
+    key    = var.account_resources_state_file
+    region = var.account_resources_state_region
   }
 }
 
 resource "aws_ecs_service" "ecs_task_serv" {
-    name = "${local.ecs_task_name}"
+    name = local.ecs_task_name
     
     // . . .
 
     network_configuration {
-        subnets =  ["${data.terraform_remote_state.account_resources.docconv_subnets}"]
+        subnets = data.terraform_remote_state.account_resources.docconv_subnets
         // . . .
     }
 }


### PR DESCRIPTION
## Overview
<!-- Briefly describe the what & why for this PR. -->
This PR upgrades the docs site to TF 0.12.

- The danger box on the IaC concepts page now reflects our new reality of `tfenv` being available everywhere
- All TF examples now use the TF 0.12 syntax

## Checklist
<!-- This is here to help you. Make sure you've done all of the below: -->
- [x] Proof-reading
- [x] Any diagrams/figures have their source files included