### PR TITLE
Disable SSPI auth in aws-adfs command

### DIFF
--- a/iac/terraform-concepts.md
+++ b/iac/terraform-concepts.md
@@ -83,7 +83,7 @@ Choose *Automatically Send this Device a Duo Push* to enable this functionality.
 Once installed, you can run the utility with the below arguments. Your username should be in the format `ads\netid`.
 
 ```sh
-aws-adfs login --adfs-host=ads-fed.northwestern.edu --provider-id urn:amazon:webservices --region us-east-2
+aws-adfs login --adfs-host=ads-fed.northwestern.edu --provider-id urn:amazon:webservices --region us-east-2 --no-sspi
 ```
 
 Once logged in, the utility will prompt you to choose the AWS account to use.


### PR DESCRIPTION
## Overview
<!-- Briefly describe the what & why for this PR. -->
On Windows, [SSPI](https://en.wikipedia.org/wiki/Security_Support_Provider_Interface) seems to be injecting some bad auth token into the login process. Recommend disabling that.

I has @cecolby11 test on OS X and it doesn't hurt anything. I let @dsd601 know, since she was having some problems on Windows -- so hopefully this fixes things for her 😁 

## Checklist
<!-- This is here to help you. Make sure you've done all of the below: -->
- [x] Proof-reading
- [x] Any diagrams/figures have their source files included