### PR TITLE
Make charts readable in light mode

### DIFF
--- a/.vuepress/config.ts
+++ b/.vuepress/config.ts
@@ -125,7 +125,9 @@ export default defineUserConfig({
                 themeVariables: {
                     darkMode: true,
                     primaryColor: '#4e2a84',
-                    primaryTextColor: '#adbac7',
+                    primaryTextColor: '#969699',
+                    primaryBorderColor: '#b6acd1',
+                    actorTextColor: '#eee',
                 },
             },
             include: true,

--- a/.vuepress/config.ts
+++ b/.vuepress/config.ts
@@ -123,11 +123,9 @@ export default defineUserConfig({
             mark: true,
             mermaid: {
                 themeVariables: {
+                    darkMode: true,
                     primaryColor: '#4e2a84',
-                    primaryTextColor: '#fff',
-                    primaryBorderColor: '#b6acd1',
-                    lineColor: '#F8B229',
-                    tertiaryColor: '#fff',
+                    primaryTextColor: '#adbac7',
                 },
             },
             include: true,


### PR DESCRIPTION
## Overview
<!-- Briefly describe the what & why for this PR. -->
The mermaid theme looks good in dark mode, but in light mode the lines & their labels are unreadable:

![image](https://user-images.githubusercontent.com/27235866/218766116-521de1c2-e449-4a6b-9823-ef7d0b3e5d23.png) ![image](https://user-images.githubusercontent.com/27235866/218766782-f519b4bd-94dc-4bfe-9764-5ab447ab16fb.png)


This removes some of the values and tells is to calculate based on colours picked for dark mode. 

It's not as nice, but I was having difficulty getting it to derive readable text colours when I picked [more of the settings](https://mermaid.js.org/config/theming.html#theme-variables). If you pick 'em, the *derived* colours will adjust for light & dark mode, but that value itself is static. And there doesn't seem to be a way to give it a value for light mode and a separate one for dark mode.

## Checklist
<!-- This is here to help you. Make sure you've done all of the below: -->
- [x] Proof-reading
- [x] Any diagrams/figures have their source files included